### PR TITLE
Add link to Trino keywords (Athena v3)

### DIFF
--- a/src/sqlfluff/dialects/dialect_athena_keywords.py
+++ b/src/sqlfluff/dialects/dialect_athena_keywords.py
@@ -1,6 +1,7 @@
 """A list of all Athena keywords.
 
-Presto List: https://prestodb.io/docs/0.217/language/reserved.html
+Presto List (for Athena v2): https://prestodb.io/docs/0.217/language/reserved.html
+Trino List (for Athena v3): https://trino.io/docs/current/language/reserved.html
 Hive List: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL
 """
 


### PR DESCRIPTION
### Brief summary of the change made
Athena v3 uses Trino engine as backend - so i've added link to Trino reserved keywords